### PR TITLE
Add dynamodb permissions to the batch service role

### DIFF
--- a/aws/terraform/metaflow/main.tf
+++ b/aws/terraform/metaflow/main.tf
@@ -62,6 +62,7 @@ module "metaflow-computation" {
   subnet_private_2_id                               = data.terraform_remote_state.infra.outputs.subnet_private_2_id
   s3_kms_policy_arn                                 = module.metaflow-datastore.metaflow_kms_s3_policy_arn
   metaflow_policy_arn                               = data.terraform_remote_state.infra.outputs.metaflow_policy_arn
+  metaflow_step_functions_dynamodb_policy           = module.metaflow-step-functions.metaflow_step_functions_dynamodb_policy
   batch_compute_environment_cpu_max_vcpus           = var.cpu_max_compute_vcpus
   batch_compute_environment_cpu_desired_vcpus       = var.cpu_desired_compute_vcpus
   batch_compute_environment_cpu_min_vcpus           = var.cpu_min_compute_vcpus

--- a/aws/terraform/metaflow/main.tf
+++ b/aws/terraform/metaflow/main.tf
@@ -72,6 +72,7 @@ module "metaflow-computation" {
   batch_compute_environment_gpu_max_vcpus           = var.gpu_max_compute_vcpus
   batch_compute_environment_gpu_desired_vcpus       = var.gpu_desired_compute_vcpus
   batch_compute_environment_gpu_min_vcpus           = var.gpu_min_compute_vcpus
+  enable_step_functions                             = var.enable_step_functions
 
   standard_tags = module.common_vars.tags
 }

--- a/aws/terraform/metaflow/modules/computation/iam.tf
+++ b/aws/terraform/metaflow/modules/computation/iam.tf
@@ -137,7 +137,7 @@ resource "aws_iam_role_policy_attachment" "batch_service_role_metaflow" {
 # If step functions are enabled, add permission to access dynamodb table
 # https://github.com/Netflix/metaflow-tools/blob/master/aws/cloudformation/metaflow-cfn-template.yml#L1066
 resource "aws_iam_role_policy" "step_functions_dynamodb" {
-  count  = length(var.metaflow_step_functions_dynamodb_policy) > 0 ? 1 : 0
+  count  = var.enable_step_functions ? 1 : 0
   name   = "Dynamodb"
   role   = aws_iam_role.batch_service_role.name
   policy = var.metaflow_step_functions_dynamodb_policy

--- a/aws/terraform/metaflow/modules/computation/iam.tf
+++ b/aws/terraform/metaflow/modules/computation/iam.tf
@@ -134,6 +134,15 @@ resource "aws_iam_role_policy_attachment" "batch_service_role_metaflow" {
   policy_arn = var.metaflow_policy_arn
 }
 
+# If step functions are enabled, add permission to access dynamodb table
+# https://github.com/Netflix/metaflow-tools/blob/master/aws/cloudformation/metaflow-cfn-template.yml#L1066
+resource "aws_iam_role_policy" "step_functions_dynamodb" {
+  count  = length(var.metaflow_step_functions_dynamodb_policy) > 0 ? 1 : 0
+  name   = "Dynamodb"
+  role   = aws_iam_role.batch_service_role.name
+  policy = var.metaflow_step_functions_dynamodb_policy
+}
+
 /*
  Attach policy AmazonEC2ContainerServiceforEC2Role to ecs_instance_role. The
  policy is what the role is allowed to do similar to rwx for a user.

--- a/aws/terraform/metaflow/modules/computation/variables.tf
+++ b/aws/terraform/metaflow/modules/computation/variables.tf
@@ -139,3 +139,9 @@ variable "metaflow_step_functions_dynamodb_policy" {
   type        = string
   description = "IAM policy allowing access to the step functions dynamodb policy"
 }
+
+variable "enable_step_functions" {
+  default     = false
+  description = "If true, apply policies required for step functions"
+  type        = bool
+}

--- a/aws/terraform/metaflow/modules/computation/variables.tf
+++ b/aws/terraform/metaflow/modules/computation/variables.tf
@@ -134,3 +134,8 @@ variable "batch_gpu_instance_types" {
     "g4dn.8xlarge"
   ]
 }
+
+variable "metaflow_step_functions_dynamodb_policy" {
+  type        = string
+  description = "IAM policy allowing access to the step functions dynamodb policy"
+}

--- a/aws/terraform/metaflow/modules/step-functions/outputs.tf
+++ b/aws/terraform/metaflow/modules/step-functions/outputs.tf
@@ -12,3 +12,8 @@ output "metaflow_step_functions_dynamodb_table_name" {
   value       = join("", [for name in aws_dynamodb_table.step_functions_state_table.*.name : name])
   description = "AWS DynamoDB table name for tracking AWS Step Functions execution metadata."
 }
+
+output "metaflow_step_functions_dynamodb_policy" {
+  value       = var.active ? data.aws_iam_policy_document.step_functions_dynamodb.json : ""
+  description = "Policy json allowing access to the step functions dynamodb table."
+}


### PR DESCRIPTION
The batch service role was missing permissions to access the dynamodb table used by step functions: https://github.com/Netflix/metaflow-tools/blob/master/aws/cloudformation/metaflow-cfn-template.yml#L1066

This PR adds those permissions if step functions are enabled.

gitter convo: https://gitter.im/metaflow_org/community?at=607df813a2ac0d38e7c7ad0c